### PR TITLE
Removing user_id from methods for getting events created by user and events that user is signed on

### DIFF
--- a/Backend/CliqueWebService/Controllers/EventController.cs
+++ b/Backend/CliqueWebService/Controllers/EventController.cs
@@ -97,8 +97,8 @@ namespace CliqueWebService.Controllers
             }
         }
 
-        [HttpGet("eventscreatedby/{user_id}")]
-        public ActionResult GetEventsCreatedByUserID(int user_id)
+        [HttpGet("LoggedUserCreatedEvents")]
+        public ActionResult GetEventsCreatedByUserID()
         {
             try
             {
@@ -108,10 +108,23 @@ namespace CliqueWebService.Controllers
             {
                 return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
             }
+            string id = "0";
+            if (Request.Headers.Keys.Contains("Authorization"))
+            {
+                string token = Request.Headers["Authorization"];
+                if (_businessLogic.isJWTValid(token.Replace("Bearer ", "")))
+                {
+                    id = User.Claims.FirstOrDefault(i => i.Type.Contains("UserId")).Value;
+                }
+            }
+            if (id == "0")
+            {
+                return Unauthorized();
+            }
             try
             {
                 List<Event> events = new List<Event>();
-                string query = $"SELECT e.*, cur.currency_abbr, u.name, u.surname, u.email, cat.category_name, g.gender_name, u.user_id FROM Events e LEFT JOIN Categories cat ON e.category = cat.category_id LEFT JOIN Users u ON e.creator = u.user_id LEFT JOIN Currencies cur ON cur.currency_id = e.currency LEFT JOIN Gender g ON u.gender = g.gender_id WHERE e.creator = {user_id} ";
+                string query = $"SELECT e.*, cur.currency_abbr, u.name, u.surname, u.email, cat.category_name, g.gender_name, u.user_id FROM Events e LEFT JOIN Categories cat ON e.category = cat.category_id LEFT JOIN Users u ON e.creator = u.user_id LEFT JOIN Currencies cur ON cur.currency_id = e.currency LEFT JOIN Gender g ON u.gender = g.gender_id WHERE e.creator = {id} ";
                 var reader = _db.ExecuteQuery(query);
                 if (!reader.HasRows)
                 {
@@ -134,8 +147,8 @@ namespace CliqueWebService.Controllers
             }
         }
 
-        [HttpGet("eventssignedup/{user_id}")]
-        public ActionResult GetEventsSignedUpByUserID(int user_id)
+        [HttpGet("LoggedUserRegisteredEvents")]
+        public ActionResult GetEventsSignedUpByUserID()
         {
             try
             {
@@ -145,14 +158,27 @@ namespace CliqueWebService.Controllers
             {
                 return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
             }
+            string id = "0";
+            if (Request.Headers.Keys.Contains("Authorization"))
+            {
+                string token = Request.Headers["Authorization"];
+                if (_businessLogic.isJWTValid(token.Replace("Bearer ", "")))
+                {
+                    id = User.Claims.FirstOrDefault(i => i.Type.Contains("UserId")).Value;
+                }
+            }
+            if (id == "0")
+            {
+                return Unauthorized();
+            }
             try
             {
                 List<Event> events = new List<Event>();
-                string query = $"SELECT e.*, cur.currency_abbr, u.name, u.surname, u.email, cat.category_name, g.gender_name, u.user_id FROM Events e LEFT JOIN Categories cat ON e.category = cat.category_id LEFT JOIN Users u ON e.creator = u.user_id LEFT JOIN Currencies cur ON cur.currency_id = e.currency LEFT JOIN Gender g ON u.gender = g.gender_id LEFT JOIN signs_up_for sg ON e.event_id = sg.event_id WHERE sg.user_id = {user_id} OR e.creator = {user_id}";
+                string query = $"SELECT e.*, cur.currency_abbr, u.name, u.surname, u.email, cat.category_name, g.gender_name, u.user_id FROM Events e LEFT JOIN Categories cat ON e.category = cat.category_id LEFT JOIN Users u ON e.creator = u.user_id LEFT JOIN Currencies cur ON cur.currency_id = e.currency LEFT JOIN Gender g ON u.gender = g.gender_id LEFT JOIN signs_up_for sg ON e.event_id = sg.event_id WHERE sg.user_id = {id} OR e.creator = {id}";
                 var reader = _db.ExecuteQuery(query);
                 if (!reader.HasRows)
                 {
-                    return BadRequest("User isn't signed in any events.");
+                    return BadRequest("User isn't signed on any events.");
                 }
                 while (reader.Read())
                 {


### PR DESCRIPTION
Removing user_id from methods for getting events created by user and events that user is signed on. Instead using JWT.